### PR TITLE
Include Compose Deploy specifications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,12 @@ services:
     volumes:
       - "./:/pr"
 
+    deploy:
+      resources:
+        limits:
+          cpus: 0.50
+          memory: 2g
+
       # enable for development
       # - "./app:/app"
       # - "./rq:/rq"


### PR DESCRIPTION
To make sure we limit the hardware requirements when docker compose is up and running.